### PR TITLE
Remove const keyword before struct Box

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,7 @@
 b2World world(b2Vec2(0, -9));
 
 // A structure with all we need to render a box
-const struct Box
+struct Box
 {
 	float width;
 	float height;


### PR DESCRIPTION
Otherwise g++ throws the following error:
‘const’ can only be specified for objects and functions